### PR TITLE
exit gracefully on SIGINT and ^d.

### DIFF
--- a/flterm.c
+++ b/flterm.c
@@ -742,7 +742,7 @@ static void do_terminal(
 		/* Data from stdin */
 		if(fds[0].revents & POLLIN) {
 			if(read(0, &c, 1) <= 0) break;
-            if(c=='\04') {
+			if(c=='\04') {
 			/* exit on ^d */
 				run_terminal = false;
 				break;

--- a/flterm.c
+++ b/flterm.c
@@ -24,10 +24,12 @@
 #include <sys/stat.h>
 #include <sys/ioctl.h>
 #include <sys/time.h>
+
 #include <ctype.h>
 #include <fcntl.h>
 #include <getopt.h>
 #include <poll.h>
+#include <signal.h>
 #include <stdbool.h>
 #include <stdio.h>
 #include <stdlib.h>
@@ -600,6 +602,16 @@ static int write_text(int serialfd, char c, enum line_end line_end) {
 	return write(serialfd, &c, 1);
 }
 
+void sig_func(int sig)
+{
+      write(1, "Caught signal 03\n", 17);
+/* need something like this to reset io
+ * else keyboard echo is off
+ * tcsetattr(0, TCSANOW, &otty);
+ */
+      exit(0);
+}
+
 static void do_terminal(
 	char *serial_port, int baud, enum line_end line_end,
 	int gdb_passthrough, int allow_xmodem,
@@ -693,6 +705,8 @@ static void do_terminal(
 	fds[0].events = POLLIN;
 	fds[1].fd = serialfd;
 	fds[1].events = POLLIN;
+
+    signal(SIGINT,sig_func); //Install the signal handler
 
 	recognized = 0;
 	flags = fcntl(serialfd, F_GETFL, 0);

--- a/flterm.c
+++ b/flterm.c
@@ -50,6 +50,8 @@
 
 #define GDBBUFLEN 1000
 
+struct termios otty, ntty;
+
 enum line_end {
 	// cr - \r - Carriage return
 	// nl - \n - Newline
@@ -604,13 +606,11 @@ static int write_text(int serialfd, char c, enum line_end line_end) {
 
 void sig_func(int sig)
 {
-      write(1, "Caught signal 03\n", 17);
-/* need something like this to reset io
- * else keyboard echo is off
- * tcsetattr(0, TCSANOW, &otty);
- */
-      exit(0);
+	write(1, "Caught signal 03 around line 609\n", 34);
+	tcsetattr(0, TCSANOW, &otty);
+	exit(0);
 }
+
 
 static void do_terminal(
 	char *serial_port, int baud, enum line_end line_end,
@@ -648,6 +648,8 @@ static void do_terminal(
 		perror("Unable to open serial port");
 		return;
 	}
+
+	signal(SIGINT,sig_func); //Install the ^c signal handler
 
 	custom_divisor = 0;
 	switch(baud) {
@@ -705,8 +707,6 @@ static void do_terminal(
 	fds[0].events = POLLIN;
 	fds[1].fd = serialfd;
 	fds[1].events = POLLIN;
-
-    signal(SIGINT,sig_func); //Install the signal handler
 
 	recognized = 0;
 	flags = fcntl(serialfd, F_GETFL, 0);
@@ -1000,7 +1000,6 @@ int main(int argc, char *argv[])
 	unsigned int initrd_address;
 	char *endptr;
 	char *log_path;
-	struct termios otty, ntty;
 
 	/* Fetch command line arguments */
 	serial_port = NULL;

--- a/flterm.c
+++ b/flterm.c
@@ -25,7 +25,6 @@
 #include <sys/stat.h>
 #include <sys/ioctl.h>
 #include <sys/time.h>
-
 #include <ctype.h>
 #include <fcntl.h>
 #include <getopt.h>
@@ -50,8 +49,6 @@
 #define DEFAULT_INITRDADR	(0x41002000)
 
 #define GDBBUFLEN 1000
-
-struct termios otty, ntty;
 
 enum line_end {
 	// cr - \r - Carriage return
@@ -1010,6 +1007,7 @@ int main(int argc, char *argv[])
 	unsigned int initrd_address;
 	char *endptr;
 	char *log_path;
+	struct termios otty, ntty;
 
 	/* Fetch command line arguments */
 	serial_port = NULL;


### PR DESCRIPTION
^c exits gracefully, but make still 'knows' (not sure what that means, I gave up.)

https://www.gnu.org/software/make/manual/make.html#Interrupts
Suppose you type Ctrl-c while a compiler is running
and
https://www.gnu.org/software/make/manual/make.html#Errors
want make to continue regardless 

do not seem to mix well.

This happens:
^CMakefile:2: recipe for target '@' failed
make: [@] Interrupt (ignored)
and the next command doesn't execute and the calling script aborts.

So I give up on ^c and now handle ^d.

Hopefully nothing needs a ^d sent to it.