### PR TITLE
Exit gracefully on ^d.

### DIFF
--- a/flterm.c
+++ b/flterm.c
@@ -742,6 +742,11 @@ static void do_terminal(
 		/* Data from stdin */
 		if(fds[0].revents & POLLIN) {
 			if(read(0, &c, 1) <= 0) break;
+			if(c=='\04') {
+				/* exit on ^d */
+				run_terminal = false;
+				break;
+			}
 			if(write_text(serialfd, c, line_end) <= 0) break;
 		}
 
@@ -1110,7 +1115,7 @@ int main(int argc, char *argv[])
 	}
 
 	/* Banner */
-	printf("[FLTERM] Starting...\n");
+	printf("[FLTERM] v2.8.2 Starting...\n");
 
 	/* Set up stdin/out */
 	tcgetattr(0, &otty);

--- a/flterm.c
+++ b/flterm.c
@@ -1115,8 +1115,7 @@ int main(int argc, char *argv[])
 	}
 
 	/* Banner */
-	printf("[FLTERM] v2.8.2 Starting...\n");
-
+	printf("[FLTERM] " GIT_VERSION " Starting...\n");
 	/* Set up stdin/out */
 	tcgetattr(0, &otty);
 	ntty = otty;


### PR DESCRIPTION
^c exits gracefully, but make still 'knows' (not sure what that means, I gave up.)

https://www.gnu.org/software/make/manual/make.html#Interrupts
Suppose you type Ctrl-c while a compiler is running
and
https://www.gnu.org/software/make/manual/make.html#Errors
want make to continue regardless

do not seem to mix well.

This happens:
^CMakefile:2: recipe for target '@' failed
make: [@] Interrupt (ignored)
and the next command doesn't execute and the calling script aborts.

So I give up on ^c and now handle ^d.

Hopefully nothing needs a ^d sent to it.