### PR TITLE
Fix installing on OSX

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -13,7 +13,7 @@ GIT_VERSION=$(shell git describe)
 
 install: flterm
 	install -d $(DESTDIR)$(PREFIX)/bin
-	install -m755 -t $(DESTDIR)$(PREFIX)/bin $^
+	install -m755 $^ $(DESTDIR)$(PREFIX)/bin
 
 .PHONY: all clean install
 


### PR DESCRIPTION
This PR fixes installing on Mac. Previous version fails as OSX `install` does not support the `-t` flag